### PR TITLE
Many features, improvements and fixes to support Jira v3.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,16 @@ Change the variables in top of the file to reflect the backup files
 ```
   ENTITIES_FILE = 'tmp/JIRA-backup-XXXXXXXX/entities.xml'
   JIRA_ATTACHMENTS_DIR = 'tmp/JIRA-backup-XXXXXXXX/data/attachments'
-  $JIRA_WEB_URL = 'https://<unix-url>.atlassian.net'
+  JIRA_PRJ_FILTER = '(TEST|DEMO)'
+  JIRA_KEY_FILTER = '[^-]+-\d{1,2}'
+  PP = false
+  MAP_PRJ_CODE_JIRA_TO_RED = {
+    'TEST'   => 'tst',
+    'DEMO'   => 'dem',
+  }
 ```
 
-and the execute the following:
+And the execute the following:
 
 ```
 rake jira_migration:test_all_migrations RAILS_ENV="production"

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -15,14 +15,12 @@ module JiraMigration
   ENTITIES_FILE = 'entities.xml'
   ############## Location of jira attachements
   JIRA_ATTACHMENTS_DIR = 'data/attachments'
-  ############## Jira URL
-  $JIRA_WEB_URL = nil
   ############## Project filter (ex: 'MYPRJ' or '(MYPRJA|MYPRJB)'
-  $JIRA_PRJ_FILTER = nil
+  JIRA_PRJ_FILTER = nil
   ############## Issue key filter (ex: '[^-]+-\d{1,2}' or '(MYPRJA-\d+|MYPRJB-\d{1,2})'
-  $JIRA_KEY_FILTER = nil
+  JIRA_KEY_FILTER = nil
   ############## Pretty print objects while testing
-  $PP = false
+  PP = false
   ############## Change project identifier here if needed (ex: { 'TST' => 'test'. } )
   MAP_PRJ_CODE_JIRA_TO_RED = {}
 
@@ -282,8 +280,8 @@ module JiraMigration
     def self.parse(xpath = '/*/Project')
       objs = super(xpath)
       # Filter projects if required
-      if !$JIRA_PRJ_FILTER.nil?
-        objs.delete_if{|obj| obj.jira_key !~ /^#{$JIRA_PRJ_FILTER}$/ }
+      if !JIRA_PRJ_FILTER.nil?
+        objs.delete_if{|obj| obj.jira_key !~ /^#{JIRA_PRJ_FILTER}$/ }
       end
       # Saving Jira id and key in a Map for later optimisation
       objs.each do |obj|
@@ -538,11 +536,11 @@ module JiraMigration
       puts "XML entities = #{nodes.size}"
         
       # Process only relevant issues
-      unless $JIRA_PRJ_FILTER.nil?
-        nodes.delete_if{|i| i['key'] !~ /^#{$JIRA_PRJ_FILTER}\-\d+$/ }
+      unless JIRA_PRJ_FILTER.nil?
+        nodes.delete_if{|i| i['key'] !~ /^#{JIRA_PRJ_FILTER}\-\d+$/ }
       end
-      unless $JIRA_KEY_FILTER.nil?
-        nodes.delete_if{|i| i['key'] !~ /^#{$JIRA_KEY_FILTER}$/ }
+      unless JIRA_KEY_FILTER.nil?
+        nodes.delete_if{|i| i['key'] !~ /^#{JIRA_KEY_FILTER}$/ }
       end
       puts "Filtered entities = #{nodes.size}"
 
@@ -1639,56 +1637,56 @@ namespace :jira_migration do
   desc "Just pretty print Jira Projects on screen"
   task :test_parse_projects => :environment do
     projects = JiraMigration::JiraProject.parse
-    projects.each {|p| pp(p.run_all_redmine_fields) } if $PP
+    projects.each {|p| pp(p.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Users on screen"
   task :test_parse_users => :environment do
     # TODO: Rework to use JiraUser::parse
     users = JiraMigration.parse_jira_users()
-    users.each {|u| pp( u.run_all_redmine_fields) } if $PP
+    users.each {|u| pp( u.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Groups on screen"
   task :test_parse_groups => :environment do
     groups = JiraMigration::JiraGroup.parse
-    groups.each {|g| pp( g.run_all_redmine_fields) } if $PP
+    groups.each {|g| pp( g.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Versions on screen"
   task :test_parse_versions => :environment do
     versions = JiraMigration::JiraVersion.parse
-    versions.each {|c| pp( c.run_all_redmine_fields) } if $PP
+    versions.each {|c| pp( c.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Components on screen"
   task :test_parse_components => :environment do
     categories = JiraMigration::JiraComponent.parse
-    categories.each {|c| pp( c.run_all_redmine_fields) } if $PP
+    categories.each {|c| pp( c.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Custom Fields on screen"
   task :test_parse_custom_fields => :environment do
     fields = JiraMigration::JiraCustomField.parse
-    fields.each {|c| pp( c.run_all_redmine_fields) } if $PP
+    fields.each {|c| pp( c.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Issues on screen"
   task :test_parse_issues => :environment do
     issues = JiraMigration::JiraIssue.parse
-    issues.each {|i| pp( i.run_all_redmine_fields) } if $PP
+    issues.each {|i| pp( i.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Comments on screen"
   task :test_parse_comments => :environment do
     comments = JiraMigration::JiraComment.parse
-    comments.each {|c| pp( c.run_all_redmine_fields) } if $PP
+    comments.each {|c| pp( c.run_all_redmine_fields) } if PP
   end
 
   desc "Just pretty print Jira Attachments on screen"
   task :test_parse_attachments => :environment do
     attachs = JiraMigration::JiraAttachment.parse
-    attachs.each {|i| pp( i.run_all_redmine_fields) } if $PP
+    attachs.each {|i| pp( i.run_all_redmine_fields) } if PP
   end
 
   ##################################### Running all tests ##########################################

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -391,7 +391,11 @@ module JiraMigration
     end
 
     def red_assigned_to_id
-      JiraMigration.find_user_by_jira_name(self.jira_lead).id
+      if self.jira_assignee
+        JiraMigration.find_user_by_jira_name(self.jira_assignee)
+      else
+        nil
+      end
     end
 
     def retrieve

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -816,6 +816,23 @@ module JiraMigration
       end
     end
 
+    memberships = self.get_list_from_tag('/*/OSMembership')
+
+    memberships.each do |m|
+      user = User.find_by_login(m['userName'])
+      if user.nil? or user == $GHOST_USER
+        users = self.get_list_from_tag("/*/OSUser[@login=\"%s\"]" % m['userName'])
+        if !users.nil? and !users.empty?
+          user = User.find_by_mail(users[0]['emailAddress'])
+        end
+      end
+      group = Group.find_by_lastname(m['groupName'])
+      if !user.nil? and !group.nil?
+        if !group.users.exists?(user.id)
+         group.users << user
+        end
+      end
+    end
   end
 
   ##############################
@@ -1004,7 +1021,6 @@ module JiraMigration
       ret.push(g)
     end
 
-    puts("Collected #{ret.size} groups")
     return ret
   end
 

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -974,15 +974,13 @@ namespace :jira_migration do
     task :migrate_issue_types => [:environment, :pre_conf] do
 
       JiraMigration.get_jira_issue_types()
-      puts "Issue types:"
       types = $confs["types"]
       types.each do |key, value|
         t = Tracker.find_by_name(value)
         if t.nil?
           t = Tracker.new(name: value)
         end
-        puts "key: " + key
-        puts "value: " + value
+        puts "key/value: " + key + '/' + value
         t.save!
         t.reload
         $MIGRATED_ISSUE_TYPES[key] = t
@@ -999,6 +997,7 @@ namespace :jira_migration do
         if s.nil?
           s = IssueStatus.new(name: value)
         end
+        puts "key/value: " + key + '/' + value
 		s.save!
         s.reload
         $MIGRATED_ISSUE_STATUS[key] = s
@@ -1016,8 +1015,7 @@ namespace :jira_migration do
         if p.nil?
           p = IssuePriority.new(name: value)
         end
-		puts "key: " + key
-		puts "value: " + value
+        puts "key/value: " + key + '/' + value
         p.save!
         p.reload
         $MIGRATED_ISSUE_PRIORITIES[key] = p

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -1164,35 +1164,6 @@ namespace :jira_migration do
       $confs = YAML.load_file(conf_file)
     end
 
-    desc "Migrates Jira Users to Redmine Users"
-    task :migrate_users => [:environment, :pre_conf] do
-      users = JiraMigration.parse_jira_users()
-      attrs = {
-        'jira_id'            => 12,
-        'jira_name'          => -24,
-        'jira_emailAddress'  => -32,
-        'jira_firstName'     => -24,
-        'jira_lastName'      => -32,
-      }
-      created = JiraMigration.migrate(users, attrs)
-      puts "Migrated users (#{created}/${users.size})"
-    end
-
-    desc "Migrates Jira Group to Redmine Group"
-    task :migrate_groups => [:environment, :pre_conf] do
-      groups = JiraMigration.parse_jira_groups()
-      attrs = {
-        'jira_id'            => 12,
-        'jira_name'          => -24,
-      }
-      created = JiraMigration.migrate(groups, attrs)
-      puts "Migrated groups (#{created}/#{groups.size})"
-
-      JiraMigration.migrate_membership
-      puts "Migrated Membership"
-
-    end
-
     desc "Migrates Jira Issue Types to Redmine Trackers"
     task :migrate_issue_types => [:environment, :pre_conf] do
 
@@ -1256,6 +1227,35 @@ namespace :jira_migration do
       }
       created = JiraMigration.migrate(projects, attrs)
       puts "Migrated projects (#{created}/#{projects.size})"
+    end
+
+    desc "Migrates Jira Users to Redmine Users"
+    task :migrate_users => [:environment, :pre_conf] do
+      users = JiraMigration.parse_jira_users()
+      attrs = {
+        'jira_id'            => 12,
+        'jira_name'          => -24,
+        'jira_emailAddress'  => -32,
+        'jira_firstName'     => -24,
+        'jira_lastName'      => -32,
+      }
+      created = JiraMigration.migrate(users, attrs)
+      puts "Migrated users (#{created}/${users.size})"
+    end
+    
+    desc "Migrates Jira Group to Redmine Group"
+    task :migrate_groups => [:environment, :pre_conf] do
+      groups = JiraMigration.parse_jira_groups()
+      attrs = {
+        'jira_id'            => 12,
+        'jira_name'          => -24,
+      }
+      created = JiraMigration.migrate(groups, attrs)
+      puts "Migrated groups (#{created}/#{groups.size})"
+    
+      JiraMigration.migrate_membership
+      puts "Migrated Membership"
+    
     end
 
     desc "Migrates Jira Versions to Redmine Versions"
@@ -1346,10 +1346,10 @@ namespace :jira_migration do
       groups.each {|g| pp( g.run_all_redmine_fields) }
     end
 
-    desc "Just pretty print Jira Comments on screen"
-    task :test_parse_comments => :environment do
-      comments = JiraMigration.parse_comments()
-      comments.each {|c| pp( c.run_all_redmine_fields) }
+    desc "Just pretty print Jira Versions on screen"
+    task :test_parse_versions => :environment do
+      versions = JiraMigration.parse_versions()
+      versions.each {|c| pp( c.run_all_redmine_fields) }
     end
 
     desc "Just pretty print Jira Components on screen"
@@ -1364,6 +1364,12 @@ namespace :jira_migration do
       issues.each {|i| pp( i.run_all_redmine_fields) }
     end
 
+    desc "Just pretty print Jira Comments on screen"
+    task :test_parse_comments => :environment do
+      comments = JiraMigration.parse_comments()
+      comments.each {|c| pp( c.run_all_redmine_fields) }
+    end
+
     desc "Just pretty print Jira Attachments on screen"
     task :test_parse_attachments => :environment do
       attachments = JiraMigration.parse_attachments()
@@ -1376,12 +1382,13 @@ namespace :jira_migration do
                                   :test_parse_projects,
                                   :test_parse_users,
                                   :test_parse_groups,
+                                  :test_parse_versions,
                                   :test_parse_components,
                                   :test_parse_issues,
                                   :test_parse_comments,
                                   :test_parse_attachments
                                   ] do
-      puts "All parsers was run! :-)"
+      puts "All parsers done! :-)"
     end
 
     ##################################### Running all tasks ##########################################
@@ -1391,9 +1398,9 @@ namespace :jira_migration do
                                 :migrate_issue_status,
                                 :migrate_issue_priorities,
                                 :migrate_projects,
-                                :migrate_versions,
                                 :migrate_users,
                                 :migrate_groups,
+                                :migrate_versions,
                                 :migrate_components,
                                 :migrate_issues,
                                 :migrate_comments,

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -970,16 +970,19 @@ namespace :jira_migration do
 
     end
 
-    desc "Migrates Jira Issue Types to Redmine Trackes"
+    desc "Migrates Jira Issue Types to Redmine Trackers"
     task :migrate_issue_types => [:environment, :pre_conf] do
 
       JiraMigration.get_jira_issue_types()
+      puts "Issue types:"
       types = $confs["types"]
       types.each do |key, value|
         t = Tracker.find_by_name(value)
         if t.nil?
           t = Tracker.new(name: value)
         end
+        puts "key: " + key
+        puts "value: " + value
         t.save!
         t.reload
         $MIGRATED_ISSUE_TYPES[key] = t

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -333,21 +333,22 @@ module JiraMigration
       self.jira_summary
     end
 	
+    # TODO: Reactivate this commented section, but it needs to be faster.
     def red_description
-	  sprints = get_previous_sprints
-	  if (sprints.to_s == '')
-	    dsc = "#{self.jira_marker}\n%s" % @jira_description
-	  else
-	    dsc = "#{self.jira_marker}\n Sprints: #{get_previous_sprints}\n\n%s" % @jira_description 
-      end	
-      return dsc	  
-      #dsc = self.jira_marker + "\n"
-      #if @jira_description
-      #  dsc += @jira_description
-      #else
-      #  dsc += self.red_subject
-      #end
-      #return dsc
+# 	  sprints = get_previous_sprints
+# 	  if (sprints.to_s == '')
+# 	    dsc = "#{self.jira_marker}\n%s" % @jira_description
+# 	  else
+# 	    dsc = "#{self.jira_marker}\n Sprints: #{get_previous_sprints}\n\n%s" % @jira_description 
+#       end	
+#       return dsc	  
+      dsc = self.jira_marker + "\n"
+      if @jira_description
+        dsc += @jira_description
+      else
+        dsc += self.red_subject
+      end
+      return dsc
     end
 
     def red_priority

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -59,6 +59,7 @@ module JiraMigration
     def migrate
       all_fields = self.run_all_redmine_fields()
       #pp('Saving:', all_fields)
+
       record = self.retrieve
       if record
         record.update_attributes(all_fields)
@@ -66,6 +67,7 @@ module JiraMigration
         record = self.class::DEST_MODEL.new all_fields
         self.is_new = true
       end
+
       if self.respond_to?('before_save')
         self.before_save(record)
       end
@@ -77,6 +79,7 @@ module JiraMigration
         puts record.errors.details
         raise
       end
+
       record.reload
 
       self.map[self.jira_id] = record
@@ -88,6 +91,7 @@ module JiraMigration
       record.reload
       return record
     end
+
     def retrieve
       self.class::DEST_MODEL.find_by_name(self.jira_id)
     end
@@ -861,8 +865,8 @@ module JiraMigration
     ret = []
     # $doc.elements.each('/*/Action[@type="comment"]') do |node|
     $doc.xpath('/*/Version').each do |node|
-      comment = JiraVersion.new(node)
-      ret.push(comment)
+      version = JiraVersion.new(node)
+      ret.push(version)
     end
     return ret
   end

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -852,13 +852,6 @@ module JiraMigration
     # Reject ignored projects
     projs.reject!{|proj|$IGNORED_PROJECTS.include?(proj.jira_key)}
 
-    migrated_projects = {}
-    projs.each do |p|
-      #puts "Name and descr.: #{p.red_name} and #{p.red_description}"
-      #puts "identifier: #{p.red_identifier}"
-      migrated_projects[p.jira_id] = p
-    end
-    #puts migrated_projects
     return projs
   end
 
@@ -1071,8 +1064,11 @@ namespace :jira_migration do
     desc "Migrates Jira Projects to Redmine Projects"
     task :migrate_projects => :environment do
       projects = JiraMigration.parse_projects()
+      printf("%-16s | %32s | %16s\n", 'jira_key', 'jira_name', 'id')
       projects.each do |p|
+        printf("%-16s | %32s | ", p.jira_key, p.jira_name)
         p.migrate
+        printf("%16s\n", p.new_record.id)
       end
     end
 

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -288,14 +288,18 @@ module JiraMigration
 
     def initialize(node)
       super
+      if @tag.at('summary')
+        @jira_summary = @tag.at('summary').text
+      else
+        @jira_summary = node['summary'].to_s
+      end
       if @tag.at('description')
         @jira_description = @tag.at('description').text
-      #elsif @tag['description']
       else
-        @jira_description = @tag['description']
+        @jira_description = node['description'].to_s
       end
-      #@jira_description = node['description'].to_s
       @jira_reporter = node['reporter'].to_s
+      @jira_assignee = node['assignee'].to_s
     end
     def jira_marker
       return "FROM JIRA: \"#{self.jira_key}\":#{$JIRA_WEB_URL}/browse/#{self.jira_key}"
@@ -999,16 +1003,6 @@ module JiraMigration
     end
 
     nodes.each do |node|
-    # If nedded, look for CDATA formatted summary in children
-	  if node['summary'].to_s.empty?
-	  	begin
-	      node['summary'] = node.at_xpath('summary').text.gsub(/\n+/, "\s")
-        rescue Exception => e
-          puts "FAILED extracting summary from #{node['key']} because of #{e.message}"
-	      # generate a summary if needed, as it can not be empty
-	  	  node['summary'] = node['key'] + " migrated without summary"
-	  	end
-	  end
 	  issue = JiraIssue.new(node)
 	  ret.push(issue)
 	end

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -137,6 +137,16 @@ module JiraMigration
     def retrieve
       self.class::DEST_MODEL.find_by_name(self.jira_id)
     end
+
+    #####################
+    def encode_for(text, attribute)
+      ret_text = ''
+      if !text.nil?
+        enc_text = text.to_s.force_encoding('UTF-8').encode('UTF-8')
+        ret_text = enc_text[0, self.class::DEST_MODEL.columns_hash[attribute.to_s].limit]
+      end
+      return ret_text
+    end
   end
 
   ###############################
@@ -177,18 +187,20 @@ module JiraMigration
     # First Name, Last Name, E-mail, Password
     # here is the tranformation of Jira attributes in Redmine attribues
     def red_firstname
-      self.jira_firstName
+      self.encode_for(self.jira_firstName, 'firstname')
     end
 
     def red_lastname
-      self.jira_lastName
+      self.encode_for(self.jira_lastName, 'lastname')
     end
 
     def red_mail
+      # Should fail validation if too long
       self.jira_emailAddress
     end
 
     def red_login
+      # Should fail validation if too long
       self.jira_name
     end
 
@@ -244,6 +256,7 @@ module JiraMigration
     end
 
     def red_name
+      # Should fail validation if too long
       self.jira_name
     end
   end
@@ -294,11 +307,11 @@ module JiraMigration
 
     # here is the tranformation of Jira attributes in Redmine attribues
     def red_name
-      self.jira_name
+      self.encode_for(self.jira_name, 'name')
     end
 
     def red_description
-      self.jira_name
+      self.encode_for(self.jira_description, 'description')
     end
 
     def red_identifier
@@ -335,11 +348,11 @@ module JiraMigration
     end
 
     def red_name
-      self.jira_name
+      self.encode_for(self.jira_name, 'name')
     end
 
     def red_description
-      self.jira_description
+      self.encode_for(self.jira_description, 'description')
     end
 
     def red_due_date
@@ -374,7 +387,7 @@ module JiraMigration
     end
 
     def red_name
-      JiraMigration.encode(self.jira_name[0, JiraMigration::limit_for(IssueCategory, 'name')])
+      self.encode_for(self.jira_name, 'name')
     end
 
     def red_assigned_to_id
@@ -428,7 +441,8 @@ module JiraMigration
     end
 
     def red_name
-      return JiraMigration.encode(self.jira_name[0, JiraMigration::limit_for(IssueCustomField, 'name')])
+      # Should fail validation if too long
+      self.jira_name
     end
 
     def red_field_format
@@ -531,14 +545,15 @@ module JiraMigration
 
     def red_category
       # Implemented in a later separated step for better performance
+      nil
     end
 
     def red_subject
-      self.jira_summary
+      self.encode_for(self.jira_summary, 'subject')
     end
 	
     def red_description
-      self.jira_description || self.jira_summary
+      self.encode_for(self.jira_description, 'description')
     end
 
     def red_priority
@@ -925,20 +940,6 @@ module JiraMigration
     ret["custom_field_types"] = self.get_jira_custom_field_types()
 
     return ret
-  end
-
-  ###############################################
-  # Return the limit size of an Redmine attribute
-  def self.limit_for(klass, attribute)
-    klass.columns_hash[attribute.to_s].limit
-  end
-
-  #####################
-  def self.encode(text)
-  	if text.nil?
-  	  text = ''
-  	end
-    text.to_s.force_encoding('UTF-8').encode('UTF-8')
   end
 
   ##################################

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -819,6 +819,9 @@ module JiraMigration
       projs.push(proj)
     end
 
+    # Reject ignored projects
+    projs.reject!{|proj|$IGNORED_PROJECTS.include?(proj.jira_key)}
+
     migrated_projects = {}
     projs.each do |p|
       #puts "Name and descr.: #{p.red_name} and #{p.red_description}"
@@ -1022,7 +1025,6 @@ namespace :jira_migration do
     desc "Migrates Jira Projects to Redmine Projects"
     task :migrate_projects => :environment do
       projects = JiraMigration.parse_projects()
-      projects.reject!{|project|$IGNORED_PROJECTS.include?(project.red_name)}
       projects.each do |p|
         p.migrate
       end

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -91,6 +91,7 @@ module JiraMigration
         puts invalid.record.errors
         puts record.errors.details
         pp self
+        pp record
         raise
       end
 

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -1244,7 +1244,7 @@ namespace :jira_migration do
     task :migrate_components => :environment do
       categories = JiraMigration.parse_components()
       categories.reject!{|category|category.red_project.nil?}
-      printf("%-32s | %-64s | %-24s | %-8s | %12s\n",
+      printf("%-24.24s | %-64.64s | %-24.24s | %-8s | %12s\n",
         'red_project',
         'red_name',
         'jira_lead',
@@ -1252,7 +1252,7 @@ namespace :jira_migration do
         'id'
       )
       categories.each do |c|
-      	printf("%-32s | %-64s | %-24s | ",
+      	printf("%-24.24s | %-64.64s | %-24.24s | ",
       	  c.red_project,
       	  c.red_name,
       	  c.jira_lead
@@ -1271,7 +1271,7 @@ namespace :jira_migration do
     task :migrate_issues => :environment do
       issues = JiraMigration.parse_issues()
       issues.reject!{|issue|issue.red_project.nil?}
-      printf("%-12s | %24s => %-24s | %-24s | %-24s | %-8s | %12s\n",
+      printf("%-12.12s | %24.24s => %-24.24s | %-24.24s | %-24.24s | %-8s | %12s\n",
         'jira_key',
         'jira_type',
         'red_tracker',
@@ -1281,7 +1281,7 @@ namespace :jira_migration do
         'id'
       )
       issues.each do |i|
-        printf("%-12s | %24s => %-24s | %-24s | %-24s | ",
+        printf("%-12.12s | %24.24s => %-24.24s | %-24.24s | %-24.24s | ",
           i.jira_key,
           $MIGRATED_ISSUE_TYPES_BY_ID[i.jira_type],
           i.red_tracker,

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -16,8 +16,8 @@ module JiraMigration
   ############## Location of jira attachements
   JIRA_ATTACHMENTS_DIR = 'data/attachments'
   ############## Jira URL
-  $JIRA_WEB_URL = 'https://company.atlassian.net'
-  ############## Project filter (ex: 'Test' or '(Test|Demo)'
+  $JIRA_WEB_URL = nil
+  ############## Project filter (ex: "MYPRJ" or "(MYPRJA|MYPRJB)"
   $JIRA_PRJ_FILTER = nil
   ############## Issue key filter (ex: '[^-]+-\d{1,2}' or '(MYPRJA-\d+|MYPRJB-\d{1,2})'
   $JIRA_KEY_FILTER = nil
@@ -242,7 +242,11 @@ module JiraMigration
     MAP = {}
 
     def jira_marker
-      return "FROM JIRA: \"#{$MAP_PROJECT_ID_TO_PROJECT_KEY[self.jira_project]}\":#{$JIRA_WEB_URL}/browse/#{$MAP_PROJECT_ID_TO_PROJECT_KEY[self.jira_project]}\n"
+      marker = "FROM JIRA: #{$MAP_PROJECT_ID_TO_PROJECT_KEY[self.jira_project]}\n"
+      if !$JIRA_WEB_URL.nil?
+        marker = "FROM JIRA: \"#{$MAP_PROJECT_ID_TO_PROJECT_KEY[self.jira_project]}\":#{$JIRA_WEB_URL}/browse/#{$MAP_PROJECT_ID_TO_PROJECT_KEY[self.jira_project]}\n"
+      end
+      return marker 
     end
 
     def retrieve
@@ -324,7 +328,11 @@ module JiraMigration
     end
 
     def jira_marker
-      return "FROM JIRA: \"#{self.jira_key}\":#{$JIRA_WEB_URL}/browse/#{self.jira_key}"
+      marker = "FROM JIRA: #{self.jira_key}"
+      if !$JIRA_WEB_URL.nil?
+        marker = "FROM JIRA: \"#{self.jira_key}\":#{$JIRA_WEB_URL}/browse/#{self.jira_key}"
+      end
+      return marker 
     end
 
     def retrieve

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -978,7 +978,7 @@ namespace :jira_migration do
       types.each do |key, value|
         t = Tracker.find_by_name(value)
         if t.nil?
-          Tracker.new(name: value)
+          t = Tracker.new(name: value)
         end
         t.save!
         t.reload

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -144,10 +144,10 @@ module JiraMigration
     MAP = {}
     ATTRF = {
       'jira_id'            => 12,
-      'jira_name'          => -24,
-      'jira_emailAddress'  => -32,
-      'jira_firstName'     => -24,
-      'jira_lastName'      => -32,
+      'jira_name'          => -18,
+      'jira_emailAddress'  => -24,
+      'jira_firstName'     => -18,
+      'jira_lastName'      => -18,
     }
 
     attr_accessor  :jira_emailAddress, :jira_name, :jira_firstName, :jira_lastName
@@ -357,7 +357,7 @@ module JiraMigration
     ATTRF = { # Main attribute names with best display size
       'jira_id'            => 12,
       'red_project'        => 24,
-      'red_name'           => -64,
+      'red_name'           => -48,
       'jira_lead'          => -24,
     }
 

--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -1310,7 +1310,7 @@ namespace :jira_migration do
       'jira_lastName'      => -32,
     }
     created = JiraMigration.migrate(users, attrs)
-    puts "Migrated users (#{created}/${users.size})"
+    puts "Migrated users (#{created}/#{users.size})"
   end
 
   ###########################################


### PR DESCRIPTION
- Support OSUser, OSGroup and OSMembership format (as seen in v3.13.2)
- Support multiple run by updating rather than re-creating (easier to fix/improve the script)
- Support regex filter at project and issue level (for partial migration or testing)
- Support Jira Components migration as Redmine Issue Categories (only the latest one)
- Support Jira key and environment fields using partial Custom Fields support (using constants)
- Remove Jira URL markers in issue and version description (doomed to become broken links anyway)
- Remove some heavy custom 'sprint' field migration (full Custom Field support still to be implemented)
- Improve performance by reducing disk I/O and memory footprint as much as possible
- Improve output by printing relevant counters and field values while migrating